### PR TITLE
Add a header for managed-evals telemetry

### DIFF
--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -22,6 +22,9 @@ import {
 
 // Configure the OpenAPI client - use relative URLs (Vite proxies /api to localhost:8000 in dev)
 OpenAPI.BASE = "";
+OpenAPI.HEADERS = {
+  'managed-evals-client-name': 'custom-review-app'
+};
 
 interface ApiError {
   error: {


### PR DESCRIPTION
As titled.

Manually tested:
<img width="3362" height="932" alt="image" src="https://github.com/user-attachments/assets/e33bc204-8d47-48f2-ae67-a7274562beb2" />
